### PR TITLE
change overflow: scroll of "DaysBody" to auto

### DIFF
--- a/src/days.tsx
+++ b/src/days.tsx
@@ -12,7 +12,7 @@ const DaysBody = styled("div")`
   max-width: 310px;
   max-height: 85%;
   position: relative;
-  overflow: hidden;
+  overflow: auto;
   border-radius: ${8 / 16}rem;
   background-color: ${props => props.theme.backColor};
   & * {

--- a/src/days.tsx
+++ b/src/days.tsx
@@ -12,7 +12,7 @@ const DaysBody = styled("div")`
   max-width: 310px;
   max-height: 85%;
   position: relative;
-  overflow: scroll;
+  overflow: hidden;
   border-radius: ${8 / 16}rem;
   background-color: ${props => props.theme.backColor};
   & * {


### PR DESCRIPTION
It has some unexpected scrollbars on my browser. 
**Google Chrome**: Version 71.0.3578.98 (Official Build) (64-bit)
**Ubuntu**: 18.04.1 LTS
![screenshot from 2019-02-13 11-35-59](https://user-images.githubusercontent.com/8453360/52696364-1837a800-2f84-11e9-9724-685361ba630b.png)


I'm aware that it may create visual bugs on smaller screens but I think the overflow behavior isn't the best solution